### PR TITLE
#166789979 Integrate Travis CI with README Badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js: 
+  - "stable"
+services:
+  - postgresql

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.com/andela/ah-92explorers-backend.svg?branch=develop)](https://travis-ci.com/andela/ah-92explorers-backend)
+
+
 Authors Haven - A Social platform for the creative at heart.
 =======
 


### PR DESCRIPTION
#### What does this PR do?
Integrates travis-ci with readme badge

#### Description of Task to be completed?
- Add a badge in readme
- Create .travis.yml
- Add defaults settings for the node project

#### How should this be manually tested?
1. Run the following commands in Terminal

```!#bash
git clone git@github.com:andela/ah-92explorers-backend.git
cd ah-92explorers-backend
git checkout ch-integrate-travisci-166789979
```

2. Navigate to `.travis.yml` file in the root directory. You will see the defaults settings

3. The `README.md` file also has a Travis CI badge to show the build status of the project.

#### Any background context you want to provide?
N/A.

#### Screenshots (if appropriate)
N/A

#### What are the relevant pivotal tracker stories?
[#166789979](https://www.pivotaltracker.com/story/show/166789979)