### PR TITLE
#166789996 Users Should Be Able To Create Their Profiles

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -12,10 +12,10 @@ sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 
 export const signup = async (req, res) => {
   const {
-    username, firstname, lastname, email, password,
+    username, firstname, lastname, email, password
   } = req.body;
   const hashedPassword = Auth.hashPassword(password);
-  const transaction = await sequelize.transaction();
+  const transaction = await sequelize.transaction({ autocommit: false });
   try {
     const newUser = await users.create({
       username,

--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -1,0 +1,120 @@
+import db from '../models';
+
+const { users } = db;
+
+/**
+* @exports Profile
+* @class Profile
+* @description Handles User Profile
+* */
+class Profile {
+  /**
+  * Get all user profiles by username
+  * @async
+  * @param  {object} req - Request object
+  * @param {object} res - Response object
+  * @return {json} Returns json object
+  * @static
+  */
+  static async getProfile(req, res) {
+    try {
+      const { username } = req.params;
+      const user = await users.findOne({
+        where: { username }
+      });
+
+      if (!user) {
+        return res.status(404).json({
+          error: 'User does not exists!',
+        });
+      }
+
+      const {
+        firstName, lastName, bio, image, phone, facebook, twitter, linkedIn, instagram, location
+      } = user;
+
+      return res.status(200).json({
+        message: 'User profile retrieved!',
+        profile: {
+          firstName,
+          lastName,
+          bio,
+          image,
+          phone,
+          facebook,
+          twitter,
+          linkedIn,
+          instagram,
+          location
+        },
+      });
+    } catch (err) {
+      return res.status(500).json({
+        error: 'Failed to retrieve user profile'
+      });
+    }
+  }
+
+  /**
+  * Update user profile
+  * @async
+  * @param  {object} req - Request object
+  * @param {object} res - Response object
+  * @return {json} Returns json object
+  * @static
+  */
+  static async updateProfile(req, res) {
+    try {
+      const { email } = req.decoded;
+      const {
+        firstName, lastName, bio, phone, facebook, twitter, linkedIn, instagram, location
+      } = req.body;
+
+      const user = await users.findOne({
+        where: { email }
+      });
+
+      if (!user) {
+        return res.status(404).json({
+          error: 'User does not exists!',
+        });
+      }
+
+      await user.update({
+        firstName,
+        lastName,
+        bio,
+        image: (req.file ? req.file.url : user.image),
+        phone,
+        facebook,
+        twitter,
+        linkedIn,
+        instagram,
+        location
+      });
+
+
+      return res.status(200).json({
+        message: 'User profile updated!',
+        profile: {
+          firstName,
+          lastName,
+          bio,
+          image: user.image,
+          phone,
+          facebook,
+          twitter,
+          linkedIn,
+          instagram,
+          location,
+        },
+      });
+    } catch (error) {
+      return res.status(500).json({
+        error: 'Failed to update user profile'
+      });
+    }
+  }
+}
+
+export default Profile;

--- a/middlewares/imageUpload.js
+++ b/middlewares/imageUpload.js
@@ -10,9 +10,8 @@ cloudinary.config({
 });
 const storage = cloudinaryStorage({
   cloudinary,
-  folder: 'articles',
+  folder: 'uploads',
   allowedFormats: ['jpg', 'png'],
-  transformation: [{ width: 500, height: 500, crop: 'limit' }]
 });
 
 const configuration = multer({ storage }).single('file');

--- a/middlewares/validations/authValidations.js
+++ b/middlewares/validations/authValidations.js
@@ -34,8 +34,10 @@ class authValidations {
         return res.status(400).json({
           error: [
             'a valid password should not be alphanumeric',
+            'a valid password should have atleast a digit, a special character and an uppercase letter',
+            'a valid password should not be alphanumeric',
             'a valid password should be 8 characters long',
-            'an example of a valid password is alphamugerwa'
+            'an example of a valid password is Explorer@47'
           ]
         });
     }
@@ -59,14 +61,42 @@ class authValidations {
         return res.status(400).json({
           error: [
             'a valid password should not be alphanumeric',
+            'a valid password should have atleast a digit, a special character and an uppercase letter',
+            'a valid password should not be alphanumeric',
             'a valid password should be 8 characters long',
-            'an example of a valid password is alphamugerwa'
+            'an example of a valid password is Explorer@47'
           ]
         });
 
       case emailRegex.test(email) === false:
         return res.status(400).json({
           error: 'please enter a valid email address e.g martinez@yahoo.com'
+        });
+    }
+
+    next();
+  }
+
+  static async validateProfile(req, res, next) {
+    const {
+      firstName, lastName, phone
+    } = req.body;
+    const nameRegex = /^[a-zA-Z]*$/;
+    const phoneRegex = /^\+[0-9]?()[0-9](\s|\S)(\d[0-9]{9})$/gm;
+
+    switch (true) {
+      case nameRegex.test(firstName) === false:
+        return res.status(400).json({
+          error: 'Firstname should be alphabetic only'
+        });
+
+      case nameRegex.test(lastName) === false:
+        return res.status(400).json({
+          error: 'Lastname should be alphabetic only'
+        });
+      case phoneRegex.test(phone) === false:
+        return res.status(400).json({
+          error: 'Provide a valid phone number, i.e:+2507213315000'
         });
     }
 

--- a/migrations/20190704173059-createTableUsers.js
+++ b/migrations/20190704173059-createTableUsers.js
@@ -5,8 +5,8 @@ export const up = (queryInterface, Sequelize) => queryInterface.createTable('use
     allowNull: false,
     primaryKey: true
   },
-  firstName: { type: Sequelize.STRING },
-  lastName: { type: Sequelize.STRING },
+  firstName: { type: Sequelize.STRING, allowNull: true },
+  lastName: { type: Sequelize.STRING, allowNull: true },
   username: {
     type: Sequelize.STRING,
     allowNull: false,
@@ -27,6 +27,38 @@ export const up = (queryInterface, Sequelize) => queryInterface.createTable('use
     allowNull: false,
     required: true
   },
+  bio: {
+    type: Sequelize.STRING,
+    allowNull: true
+  },
+  image: {
+    type: Sequelize.STRING,
+    allowNull: true
+  },
+  phone: {
+    type: Sequelize.STRING,
+    allowNull: true
+  },
+  facebook: {
+    type: Sequelize.STRING,
+    allowNull: true
+  },
+  twitter: {
+    type: Sequelize.STRING,
+    allowNull: true
+  },
+  linkedIn: {
+    type: Sequelize.STRING,
+    allowNull: true
+  },
+  instagram: {
+    type: Sequelize.STRING,
+    allowNull: true
+  },
+  location: {
+    type: Sequelize.STRING,
+    allowNull: true
+  },
   accessLevel: {
     type: Sequelize.INTEGER,
     defaultValue: '0'
@@ -45,7 +77,7 @@ export const up = (queryInterface, Sequelize) => queryInterface.createTable('use
     allowNull: false,
     type: Sequelize.DATE,
     defaultValue: Sequelize.fn('now')
-  },
+  }
 });
 
 export const down = queryInterface => queryInterface.dropTable('users');

--- a/models/users.js
+++ b/models/users.js
@@ -6,8 +6,8 @@ export default (sequelize, DataTypes) => {
       allowNull: false,
       primaryKey: true
     },
-    firstName: { type: DataTypes.STRING },
-    lastName: { type: DataTypes.STRING },
+    firstName: { type: DataTypes.STRING, allowNull: true },
+    lastName: { type: DataTypes.STRING, allowNull: true },
     username: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -27,6 +27,38 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
       required: true
+    },
+    bio: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    image: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    phone: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    facebook: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    twitter: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    linkedIn: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    instagram: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    location: {
+      type: DataTypes.STRING,
+      allowNull: true
     },
     accessLevel: {
       type: DataTypes.INTEGER,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6008,9 +6008,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.1.tgz",
-      "integrity": "sha512-zzOLNRxzszwd+61JFuAo0fxdQfvku12aNJgnla0AQ+hHxFmfc/B7jBVuPr5Rmvu46Jze/iJrFpSOsD7afO8SDw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.2.tgz",
+      "integrity": "sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==",
       "requires": {
         "append-field": "^1.0.0",
         "busboy": "^0.2.11",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "babel-node index.js && redis-server",
     "dev": "NODE_ENV=development nodemon ./index.js --exec babel-node",
-    "test": "NODE_ENV=test npm run setup:test && mocha --require @babel/register ./tests --timeout 10000 --exit",
+    "test": "NODE_ENV=test npm run setup:test && NODE_ENV=test mocha --require @babel/register ./tests --timeout 10000 --exit",
     "setup:test": "NODE_ENV=test npm run migrate:undo && NODE_ENV=test npm run migrate && NODE_ENV=test npm run seed",
     "setup:dev": "NODE_ENV=development npm run migrate:undo && NODE_ENV=development npm run migrate && NODE_ENV=development npm run seed",
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls && nyc --reporter=lcov --reporter=text-lcov npm test",
@@ -91,9 +91,11 @@
   },
   "nyc": {
     "exclude": [
-      "test/*",
+      "tests/*",
       "models/*",
+      "helpers/",
       "migrations/*",
+      "middlewares/checkDb.js",
       "seeders/*",
       "config/*",
       "index.js"

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-named-as-default */
 
 import express from 'express';
 import passport from '../../middlewares/passport';
@@ -5,6 +6,8 @@ import {
   signup, signin, verifyUser, signoutUser,
 } from '../../controllers';
 import Validations from '../../middlewares/validations/authValidations';
+import Profile from '../../controllers/profile';
+import uploadImage from '../../middlewares/imageUpload';
 import { checkToken } from '../../middlewares';
 import socialAuth from '../../controllers/socialAuth';
 import resetPasswordController from '../../controllers/resetPassword';
@@ -219,5 +222,106 @@ router.get('/reset-password/:token', resetPasswordController.getToken);
 router.put('/password', Validations.validatePasswordOnReset, resetPasswordController.resetPassword);
 
 router.post('/users/signout', checkToken, signoutUser);
+
+/**
+* @swagger
+* /api/profiles/:username:
+*   get:
+*      tags:
+*      - users
+*      name: Signin
+*      summary: "Users with profiles"
+*      description: "Returns all users and their corresponding profiles"
+*      operationId: "getUsers"
+*      produces:
+*      - "application/json"
+*      parameters: []
+*      responses:
+*        200:
+*          description: "User profile retrieved!"
+*          schema:
+*            $ref: "#/definitions/ApiResponse"
+*        404:
+*          description: "User does not exists!"
+*/
+router.get('/profiles/:username', checkToken, Profile.getProfile);
+
+/**
+* @swagger
+* /api/profiles/:username:
+*   put:
+*     tags:
+*     - "profiles"
+*     summary: "Update User Profile"
+*     description: "Returns the Updated User Details"
+*     operationId: "updateProfile"
+*     produces:
+*     - "application/json"
+*     parameters:
+*     - in: "formData"
+*       name: firstname
+*       required: false
+*       type: string
+*       description: "first name"
+*     - in: "formData"
+*       name: lastname
+*       required: false
+*       type: string
+*       description: "last name"
+*     - in: "formData"
+*       name: bio
+*       required: false
+*       type: text
+*       description: "bio"
+*     - in: "formData"
+*       name: image
+*       required: false
+*       type: string
+*       description: "Image URL"
+*     - in: "formData"
+*       name: location
+*       required: false
+*       type: string
+*       description: "Location"
+*     - in: "formData"
+*       name: facebook
+*       required: false
+*       type: string
+*       description: "Facebook URL"
+*     - in: "formData"
+*       name: twitter
+*       required: false
+*       type: string
+*       description: "Twitter URL"
+*     - in: "formData"
+*       name: linkedIn
+*       required: false
+*       type: string
+*       description: "linkedIn URL"
+*     - in: "formData"
+*       name: instagram
+*       required: false
+*       type: string
+*       description: "Instagram URL"
+*     - in: "formData"
+*       name: phone
+*       required: false
+*       type: integer
+*       description: 'Phone Number'
+*       minLength: 11
+*       maxLength: 14
+*     responses:
+*       200:
+*         description: "User profile updated!"
+*         schema:
+*           $ref: "#/definitions/ApiResponse"
+*       400:
+*         description: "Invalid token supplied: format Bearer <token>"
+*       401:
+*         description: "Invalid Token Provided"
+*       404:
+*         description: "User does not exists!"
+*/
+router.patch('/profiles', checkToken, uploadImage, Validations.validateProfile, Profile.updateProfile);
 
 export default router;

--- a/seeders/20190717084942-articles.js
+++ b/seeders/20190717084942-articles.js
@@ -8,7 +8,7 @@ export const up = (queryInterface, Sequelize) => queryInterface.bulkInsert(
       title: 'The basics of java',
       slug: 'the-basics-of-java',
       body: 'JavaScript is a language which has many frameworks and libraries',
-      tagList: ['nodejs', 'programming'],
+      tagList: '{nodejs, programming}',
       authorId: 'c90dee64-663d-4d8b-b34d-12acba22cd32',
       createdAt: '2019-07-17 06:32:44.631+02',
       updatedAt: '2019-07-17 06:32:44.631+02',

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -12,7 +12,10 @@ describe('Testing if an admin can login', () => {
   it('should login an admin', (done) => {
     chai.request(app)
       .post('/api/users/login')
-      .send(user.adminLogin)
+      .send({
+        email: 'ackram@gmail.com',
+        password: 'Alphamugerwa12$'
+      })
       .end((err, res) => {
         const { status, body } = res;
         expect(status).to.equal(200);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -55,6 +55,36 @@ const emailVerification = {
   password: 'Explorers@92',
 };
 
+const profile = {
+  firstName: 'isaiah',
+  lastName: 'runr',
+  bio: 'A software developer and author',
+  image: 'https://lh6.googleusercontent.com/-sZOpms2mUso/AAAAAAAAAAI/AAAAAAAAAgY/qI2F0nXUaU8/photo.jpg',
+  phone: '+078899000000',
+  facebook: 'facebook.com/isaiahRn',
+  twitter: 'twitter.com/isaiahRn',
+  linkedIn: 'linkedin.com/isaiahRn',
+  instagram: 'instagram.com/isaiahRn',
+  location: 'gisozi',
+};
+
+const userSignup = {
+  username: 'isaiah250',
+  email: 'isaiah@mail.com',
+  password: 'Explorer@22'
+};
+
+const userLogin = {
+  email: 'isaiah@mail.com',
+  password: 'Explorer@22'
+};
+
+const invalidUpdate = {
+  firstName: 'isaiah50',
+  lastName: 'run23',
+  phone: '0930209309'
+};
+
 const roleLevel = {
   accessLevel: 1
 };
@@ -145,4 +175,8 @@ export default {
   userAdmin,
   adminLogin,
   comment,
+  userSignup,
+  userLogin,
+  invalidUpdate,
+  profile,
 };

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -1,0 +1,135 @@
+/* eslint-disable no-unused-vars */
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+import db from '../models';
+import user from './index.test';
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+let tokenGen;
+let userName;
+
+describe('User Profile', () => {
+  before(() => {
+    db.users.destroy({
+      where: {
+        email: user.userSignup.email
+      }
+    });
+  });
+
+  it('creating new user', (done) => {
+    chai.request(app)
+      .post('/api/users')
+      .send(user.userSignup)
+      .end((req, res) => {
+        const { status, body } = res;
+        expect(status).to.equal(201);
+        expect(res.body).to.be.an('object');
+        expect(body).to.have.property('message');
+        expect(body).to.have.property('user');
+        expect(body.user).to.have.property('username');
+        expect(body.user).to.have.property('email');
+        expect(body.user).to.have.property('token');
+        userName = body.user.username;
+        done();
+      });
+  });
+  it('should be able to sign in', (done) => {
+    chai.request(app)
+      .post('/api/users/login')
+      .send(user.userLogin)
+      .end((req, res) => {
+        const { status, body } = res;
+        expect(status).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(body).to.have.property('message');
+        expect(body).to.have.property('user');
+        expect(body.user).to.have.property('email');
+        expect(body.user).to.have.property('username');
+        expect(body.user).to.have.property('token');
+        expect(body.message).to.equals('logged in');
+        tokenGen = body.user.token;
+        done();
+      });
+  });
+
+  it('should be able user to see its profile after signup', (done) => {
+    chai.request(app)
+      .get(`/api/profiles/${userName}`)
+      .set('Authorization', `Bearer ${tokenGen}`)
+      .end((req, res) => {
+        const { status, body } = res;
+        expect(status).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(body).to.have.property('message');
+        expect(body).to.have.property('profile');
+        expect(body.profile).to.have.property('firstName');
+        expect(body.profile).to.have.property('lastName');
+        expect(body.profile).to.have.property('bio');
+        expect(body.profile).to.have.property('phone');
+        expect(body.profile).to.have.property('facebook');
+        expect(body.profile).to.have.property('twitter');
+        expect(body.profile).to.have.property('linkedIn');
+        expect(body.profile).to.have.property('instagram');
+        expect(body.profile).to.have.property('location');
+        expect(body.message).to.equals('User profile retrieved!');
+        done();
+      });
+  });
+
+  it('should not see profile if the username does not exist', (done) => {
+    chai.request(app)
+      .get('/api/profiles/jjdsjnjdj')
+      .set('Authorization', `Bearer ${tokenGen}`)
+      .end((req, res) => {
+        const { status, body } = res;
+        expect(status).to.equal(404);
+        expect(res.body).to.be.an('object');
+        expect(body).to.have.property('error');
+        expect(body.error).to.equals('User does not exists!');
+        done();
+      });
+  });
+
+  it('User should be able to update its profile', (done) => {
+    chai.request(app)
+      .patch('/api/profiles')
+      .set('Authorization', `Bearer ${tokenGen}`)
+      .send(user.profile)
+      .end((err, res) => {
+        const { status, body } = res;
+        expect(status).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(body).to.have.property('message');
+        expect(body).to.have.property('profile');
+        expect(body.profile).to.have.property('firstName');
+        expect(body.profile).to.have.property('lastName');
+        expect(body.profile).to.have.property('bio');
+        expect(body.profile).to.have.property('image');
+        expect(body.profile).to.have.property('phone');
+        expect(body.profile).to.have.property('facebook');
+        expect(body.profile).to.have.property('twitter');
+        expect(body.profile).to.have.property('linkedIn');
+        expect(body.profile).to.have.property('instagram');
+        expect(body.profile).to.have.property('location');
+        expect(body.message).to.equals('User profile updated!');
+        done();
+      });
+  });
+  it('should not update profile if the token is not provided', (done) => {
+    chai.request(app)
+      .patch('/api/profiles/')
+      .send(user.profile)
+      .end((err, res) => {
+        const { status, body } = res;
+        expect(status).to.equal(401);
+        expect(res.body).to.be.an('object');
+        expect(body).to.have.property('error');
+        expect(body.error).to.equals('unauthorised to use this resource, please signup/login');
+        done();
+      });
+  });
+});

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -31,7 +31,7 @@ describe('Validate user inputs on signup', () => {
         expect(status).to.equal(400);
         expect(body).to.have.property('error');
         expect(body.error[0]).to.equals('a valid password should not be alphanumeric');
-        expect(body.error[1]).to.equals('a valid password should be 8 characters long');
+        expect(body.error[1]).to.equals('a valid password should have atleast a digit, a special character and an uppercase letter');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?

- Add a feature to create a user profile

#### Description of Task to be completed

- After successful registration, a user profile must be created.

- User should be able to view and Edit/Update his own profile.

#### How should this be manually tested?

1. Run the following commands in your terminal

```
git clone https://github.com/andela/ah-92explorers-backend.git
cd ah-92explorers-backend
git checkout ft-create-profiles-166789996
npm install
npm start
```

2. Go to Postman

- Register a user via `localhost:3000/api/users`

- To view a profile, navigate to `localhost:3000/api/profiles/:username`, 

- To Edit a profile, navigate to `localhost:3000/api/profiles/:username`


#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?
[#166789996](https://www.pivotaltracker.com/story/show/166789996)
#### Screenshots (if appropriate)

- View user profile
<img width="953" alt="Screen Shot 2019-07-17 at 12 30 45" src="https://user-images.githubusercontent.com/40357462/61368794-f1f99980-a88e-11e9-92bd-f106bd609ee2.png">




- Edit user profile
<img width="956" alt="Screen Shot 2019-07-17 at 12 31 02" src="https://user-images.githubusercontent.com/40357462/61368817-fe7df200-a88e-11e9-903d-9ba391bb3842.png">





#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I don't have more than 3 major commits on this PR