### PR TITLE
#166790014 Users Should Be Able to Like a Specific Comment

### DIFF
--- a/controllers/comment.js
+++ b/controllers/comment.js
@@ -30,7 +30,7 @@ export const createComment = async (req, res) => {
           }],
         });
         const {
-          author, createdAt, updatedAt,
+          id, author, createdAt, updatedAt,
         } = showComment;
         const articleRef = {
           slug: article.slug
@@ -38,6 +38,7 @@ export const createComment = async (req, res) => {
         return res.status(201).json({
           message: 'commented',
           comment: {
+            id,
             body: showComment.body,
             author,
             article: articleRef,

--- a/controllers/likeComment.js
+++ b/controllers/likeComment.js
@@ -1,0 +1,49 @@
+import models from '../models';
+
+const {
+  comments, commentLikes, users, articles
+} = models;
+
+/**
+* Class to control likes for comments
+*/
+export default class CommentLikes {
+  static async likeComment(req, res) {
+    try {
+      const comment = await comments.findOne({
+        where: { id: req.params.commentId }, attributes: ['id', 'body', 'articleId']
+      });
+
+      const author = await users.findOne({
+        where: { email: req.decoded.email }, attributes: ['id', 'firstName', 'lastName']
+      });
+
+      const article = await articles.findOne({
+        where: { id: comment.articleId }, attributes: ['id', 'slug']
+      });
+
+      const like = await commentLikes.findOne({
+        where: { userId: author.id, commentId: comment.id, likes: 1 }
+      });
+
+      if (!like) {
+        await commentLikes.create({
+          userId: author.id,
+          commentId: comment.id,
+          articleSlug: article.slug,
+          likes: 1,
+        });
+        return res.status(201).json({
+          message: 'you liked this comment',
+        });
+      }
+
+      await like.destroy({ userId: author.id, likes: 1 });
+      return res.status(200).json({
+        message: 'you unliked this comment',
+      });
+    } catch (error) {
+      return res.status(500).json({ error: 'Failed to like this comment, please try again' });
+    }
+  }
+}

--- a/migrations/20190718173169-createTableCommentLikes.js
+++ b/migrations/20190718173169-createTableCommentLikes.js
@@ -1,0 +1,40 @@
+export const up = (queryInterface, Sequelize) => queryInterface.createTable('commentLikes', {
+  id: {
+    allowNull: false,
+    primaryKey: true,
+    type: Sequelize.UUID,
+    defaultValue: Sequelize.UUIDV4,
+  },
+  userId: {
+    type: Sequelize.UUID,
+    defaultValue: Sequelize.UUIDV4,
+  },
+  commentId: {
+    type: Sequelize.UUID,
+    defaultValue: Sequelize.UUIDV4,
+  },
+  articleSlug: {
+    type: Sequelize.STRING,
+    allowNull: false,
+    references: {
+      model: 'articles',
+      key: 'slug'
+    },
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE'
+  },
+  likes: {
+    type: Sequelize.INTEGER,
+    allowNull: true
+  },
+  createdAt: {
+    allowNull: false,
+    type: Sequelize.DATE
+  },
+  updatedAt: {
+    allowNull: false,
+    type: Sequelize.DATE
+  }
+});
+
+export const down = queryInterface => queryInterface.dropTable('commentLikes');

--- a/models/commentLikes.js
+++ b/models/commentLikes.js
@@ -1,0 +1,73 @@
+export default (sequelize, DataTypes) => {
+  const CommentLikes = sequelize.define(
+    'commentLikes',
+    {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+      },
+      userId: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: true,
+        references: {
+          model: 'users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL'
+      },
+      commentId: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: true,
+        references: {
+          model: 'comments',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL'
+      },
+      articleSlug: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        references: {
+          model: 'articles',
+          key: 'slug'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      likes: {
+        allowNull: true,
+        type: DataTypes.INTEGER
+      },
+      createdAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      }
+    },
+    {}
+  );
+  CommentLikes.associate = (models) => {
+    CommentLikes.belongsTo(models.comments, { foreignKey: 'commentId', as: 'comment' });
+    CommentLikes.belongsTo(models.users, { foreignKey: 'userId', as: 'user' });
+    models.users.belongsToMany(models.comments, {
+      through: models.commentLikes,
+      foreignKey: 'userId',
+      otherKey: 'commentId'
+    });
+    models.comments.belongsToMany(models.users, {
+      through: models.commentLikes,
+      foreignKey: 'commentId',
+      otherKey: 'userId'
+    });
+  };
+  return CommentLikes;
+};

--- a/routes/api/likes.js
+++ b/routes/api/likes.js
@@ -1,10 +1,45 @@
 import express from 'express';
 import { checkToken } from '../../middlewares';
 import likeController from '../../controllers/likes';
+import CommentLikes from '../../controllers/likeComment';
 
 const router = express.Router();
 router.post('/like/:articleSlug', checkToken, likeController.likeArticle);
 router.post('/dislike/:articleSlug', checkToken, likeController.dislikeArticle);
 router.post('/favorite/:articleSlug', checkToken, likeController.likeArticle);
+
+
+// @Method POST
+// @Desc like a comment, Authentication required
+/**
+* @swagger
+* /api/article/comment/{commentId}/like:
+*   post:
+*     security:
+*       - bearerAuth: []
+*     tags:
+*       - Like
+*     name: like a comment
+*     summary: Like a comment on article
+*     consumes:
+*       - application/json
+*     parameters:
+*       - name: commentId
+*         in: path
+*         required: true
+*         description: commentId that represents a comment
+*         type: string
+*     responses:
+*       201:
+*         description: you liked a comment
+*       200:
+*         description: you unliked a comment
+*       401:
+*         description: unauthorised to use this resource, please signup/login
+*       500:
+*         description: Failed to like this comment, please try again
+*/
+
+router.post('/article/comment/:commentId/like', checkToken, CommentLikes.likeComment);
 
 export default router;

--- a/seeders/20190719084942-commentLikes.js
+++ b/seeders/20190719084942-commentLikes.js
@@ -1,0 +1,28 @@
+import uuid from 'uuidv4';
+
+export const up = (queryInterface, Sequelize) => queryInterface.bulkInsert(
+  'commentLikes',
+  [
+    {
+      id: uuid(),
+      userId: 'c90dee64-663d-4d8b-b34d-12acba22cd32',
+      commentId: '1e8150b6-d410-4eee-bccc-60809ff8d11d',
+      articleSlug: 'the-basics-of-java',
+      likes:1,
+      createdAt: '2019-07-19 06:32:44.631+02',
+      updatedAt: '2019-07-19 06:32:44.631+02',
+    },
+    {
+      id: uuid(),
+      userId: 'c90dee64-663d-4d8b-b34d-12acba22cd68',
+      commentId: '1e8150b6-d410-4eee-bccc-60809ff8d11d',
+      articleSlug: 'the-basics-of-java',
+      likes:1,
+      createdAt: '2019-07-19 06:32:44.631+02',
+      updatedAt: '2019-07-19 06:32:44.631+02',
+    },
+  ],
+  {}
+);
+ 
+const down = (queryInterface, Sequelize) => queryInterface.bulkDelete('commentLikes', null, {});

--- a/tests/likeComment.test.js
+++ b/tests/likeComment.test.js
@@ -1,0 +1,104 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+import dummyData from './index.test';
+
+
+chai.use(chaiHttp);
+
+const { expect } = chai;
+const userToken = [];
+
+const slugArticle = 'the-basics-of-java';
+let commentId;
+
+describe('Testing if user login', () => {
+  it('should login an admin', (done) => {
+    chai.request(app)
+      .post('/api/users/login')
+      .send(dummyData.adminLogin)
+      .end((err, res) => {
+        const { status, body } = res;
+        expect(status).to.equal(200);
+        expect(body).to.have.property('message');
+        expect(body).to.have.property('user');
+        expect(body.user).to.have.property('email');
+        expect(body.user).to.have.property('username');
+        expect(body.message).to.equals('logged in');
+        userToken.push(body.user.token);
+        done();
+      });
+  });
+
+  it('Should let user comment on article with valid details', (done) => {
+    chai
+      .request(app)
+      .post(`/api/articles/${slugArticle}/comments`)
+      .set('Authorization', `Bearer ${userToken[0]}`)
+      .send(dummyData.comment)
+      .end((err, res) => {
+        expect(typeof res.statusCode).to.be.equal('number');
+        expect(res.statusCode).to.be.equal(201);
+        expect(typeof res.body.comment.body).to.be.equal('string');
+        expect(res.body.comment.body).to.be.equal('My dragon is finally flying');
+        expect(typeof res.body.comment.author).to.be.equal('object');
+        expect(res.body.comment.author).to.have.property('username');
+        expect(res.body.comment).to.have.property('createdAt');
+        expect(res.body.comment).to.have.property('updatedAt');
+        commentId = res.body.comment.id; // comment id
+        done();
+      });
+  });
+
+  it('should not allow a user to like a comment with invalid article id', (done) => {
+    chai.request(app)
+      .post(`/api/article/comment/${commentId}2/like`)
+      .set('Authorization', `Bearer ${userToken[0]}`)
+      .end((error, res) => {
+        const { status, body } = res;
+        expect(status).to.equal(500);
+        expect(body).to.have.property('error');
+        expect(body.error).to.have.equals('Failed to like this comment, please try again');
+        done();
+      });
+  });
+
+  it('should not allow user to like without authorization', (done) => {
+    chai
+      .request(app)
+      .post(`/api/article/comment/${commentId}/like`)
+      .set('Content-Type', 'application/json')
+      .end((err, res) => {
+        const { status } = res;
+        expect(status).to.equal(401);
+        expect(res.body.error).to.be.equal('unauthorised to use this resource, please signup/login');
+        done();
+      });
+  });
+
+  it('should allow a user to like a comment', (done) => {
+    chai.request(app)
+      .post(`/api/article/comment/${commentId}/like`)
+      .set('Authorization', `Bearer ${userToken[0]}`)
+      .end((error, res) => {
+        const { status, body } = res;
+        expect(status).to.equal(201);
+        expect(body).to.have.property('message');
+        expect(body.message).to.have.equals('you liked this comment');
+        done();
+      });
+  });
+
+  it('should allow a user to unlike a comment', (done) => {
+    chai.request(app)
+      .post(`/api/article/comment/${commentId}/like`)
+      .set('Authorization', `Bearer ${userToken[0]}`)
+      .end((error, res) => {
+        const { status, body } = res;
+        expect(status).to.equal(200);
+        expect(body).to.have.property('message');
+        expect(body.message).to.have.equals('you unliked this comment');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Enables a user to like a comment
#### Description of Task to be completed
- To set up like a comment functionality
#### How should this be manually tested?
1. Run the following commands in the terminal
```
git clone https://github.com/andela/ah-92explorers-backend.git
cd ah-92explorers-backend
git checkout ft-user-like-specific-comment-166790014
npm install
npm start
```
2. Create a .env file and add the following snippets
```
DATABASE_URL=postgres://username:password@localhost:5432/authorshaven
DATABASE_=postgres://username:password@localhost:5432/authorshaven_test
```
3. Install `sequelize` globally
```
sudo npm install -g sequelize
```
4.  Create a database using `sequelize db:create`
5. Run the following requests in Postman using `localhost:3000`
|  `POST`  |  `/api/article/comment/:articleId/like`  |  `like a comment`  |
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#166790014](https://www.pivotaltracker.com/story/show/166790014)
#### Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I don't have more than 3 major commits on this PR