### PR TITLE
#166790011 Share Articles Across Different Channels

### DIFF
--- a/controllers/article.js
+++ b/controllers/article.js
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
 import he from 'he';
+import open from 'open';
 import models from '../models';
 
 const { articles, users } = models;
@@ -185,6 +186,51 @@ class Article {
       return res.status(204).send('');
     } catch (error) {
       return res.status(500).json({ error: 'Failed to delete article, please try again' });
+    }
+  }
+
+  /**
+   *
+   * @param {Object} req
+   * @param {Object} res
+   * @returns {object} response
+   */
+  static async shareArticle(req, res) {
+    const { slug, channel } = req.params;
+    const articleSlug = await articles.findOne({
+      where: { slug: req.params.slug }
+    });
+    if (!articleSlug) {
+      return res.status(404).json({
+        status: 404,
+        message: 'Article is not found.'
+      });
+    }
+    const url = `${process.env.APP_URL}/api/articles/${slug}/share/${channel}`;
+    switch (channel) {
+      case 'facebook':
+        if (process.env.NODE_ENV !== 'test') open(`https:www.facebook.com/sharer/sharer.php?u=${url}`);
+        res.status(200).json({
+          status: 200,
+          message: `Article shared to ${channel}`,
+        });
+        break;
+      case 'twitter':
+        if (process.env.NODE_ENV !== 'test') { open(`https://twitter.com/intent/tweet?url=${url}`); }
+        res.status(200).json({
+          status: 200,
+          message: `Article shared to ${channel}`,
+        });
+        break;
+      case 'mail':
+        if (process.env.NODE_ENV !== 'test') open(`mailto:?subject=${slug}&body=${url}`);
+        res.status(200).json({
+          status: 200,
+          message: `Article shared to ${channel}`,
+        });
+        break;
+      default:
+        break;
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5077,6 +5077,11 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -6519,6 +6524,14 @@
       "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
       "requires": {
         "format-util": "^1.0.3"
+      }
+    },
+    "open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+      "requires": {
+        "is-wsl": "^1.1.0"
       }
     },
     "openapi-schema-validation": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "babel-node index.js && redis-server",
     "dev": "NODE_ENV=development nodemon ./index.js --exec babel-node",
-    "test": "NODE_ENV=test npm run setup:test && mocha --require @babel/register ./tests --timeout 10000 --exit",
+    "test": "NODE_ENV=test npm run setup:test && NODE_ENV=test mocha --require @babel/register ./tests --timeout 10000 --exit",
     "setup:test": "NODE_ENV=test npm run migrate:undo && NODE_ENV=test npm run migrate && NODE_ENV=test npm run seed",
     "setup:dev": "NODE_ENV=development npm run migrate:undo && NODE_ENV=development npm run migrate && NODE_ENV=development npm run seed",
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls && nyc --reporter=lcov --reporter=text-lcov npm test",
@@ -51,6 +51,7 @@
     "nodemailer": "^6.2.1",
     "nodemailer-smtp-transport": "^2.7.4",
     "nodemon": "^1.19.1",
+    "open": "^6.4.0",
     "passport": "^0.4.0",
     "passport-facebook": "^3.0.0",
     "passport-google": "^0.3.0",
@@ -91,9 +92,10 @@
   },
   "nyc": {
     "exclude": [
-      "test/*",
+      "tests/*",
       "models/*",
       "migrations/*",
+      "middlewares/checkDb.js",
       "seeders/*",
       "config/*",
       "index.js"

--- a/routes/api/articles.js
+++ b/routes/api/articles.js
@@ -195,4 +195,39 @@ router.delete('/articles/:slug', checkToken, checkArticleOwner, article.deleteAr
 */
 router.post('/articles/:slug/comments', checkToken, createComment);
 
+/**
+* @swagger
+*  /api/articles/{slug}/share/{channel}:
+*    post:
+*      security:
+*       - bearerAuth: []
+*      tags:
+*        - Articles
+*      summary: Share an article
+*      description: returns the status and message.
+*      produces:
+*        - application/json
+*      parameters:
+*        - in: path
+*          name: slug
+*          schema:
+*            type: string
+*          required: true
+*          description: The author username
+*        - in: path
+*          name: channel
+*          schema:
+*            type: string
+*          required: true
+*          description: Channel have to be either facebook, twitter  or mail
+*      responses:
+*        200:
+*          description: The success message
+*        400:
+*          description: channel must be one of facebook, twitter, mail
+*        404:
+*          description: Article is not found.
+*/
+router.post('/articles/:slug/share/:channel', article.shareArticle);
+
 export default router;

--- a/tests/article.test.js
+++ b/tests/article.test.js
@@ -3,10 +3,13 @@ import chaiHttp from 'chai-http';
 import app from '../index';
 import dummy from './index.test';
 
+const { expect } = chai;
 chai.use(chaiHttp);
 
 let authToken;
 let articleSlug;
+const slugArticle = 'the-basics-of-java';
+
 
 describe('CRUD articles routes', () => {
   // @user login
@@ -246,6 +249,61 @@ describe('CRUD articles routes', () => {
       });
   });
 });
+
+describe('Share articles across different channels', () => {
+  it('should send back a token after sucessful login', (done) => {
+    chai.request(app)
+      .post('/api/users/login')
+      .send(dummy.adminLogin)
+      .then((res) => {
+        res.should.have.status(200);
+        authToken = res.body.user.token; // get the token
+        done();
+      })
+      .catch(err => done(err));
+  });
+  it('should not share if the article is not found', (done) => {
+    chai.request(app)
+      .post(`/api/articles/${slugArticle}-6778/share/facebook`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .end((error, res) => {
+        expect(res.body.status).to.be.equal(404);
+        expect(res.body.message).to.equals('Article is not found.');
+        done();
+      });
+  });
+  it('should  share to facebook', (done) => {
+    chai.request(app)
+      .post(`/api/articles/${slugArticle}/share/facebook`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .end((error, res) => {
+        expect(res.body.status).to.be.equal(200);
+        expect(res.body.message).to.equals('Article shared to facebook');
+        done();
+      });
+  });
+  it('should  share to twitter', (done) => {
+    chai.request(app)
+      .post(`/api/articles/${slugArticle}/share/twitter`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .end((error, res) => {
+        expect(res.body.status).to.be.equal(200);
+        expect(res.body.message).to.equals('Article shared to twitter');
+        done();
+      });
+  });
+  it('should  share to mail', (done) => {
+    chai.request(app)
+      .post(`/api/articles/${slugArticle}/share/mail`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .end((error, res) => {
+        expect(res.body.status).to.be.equal(200);
+        expect(res.body.message).to.equals('Article shared to mail');
+        done();
+      });
+  });
+});
+
 
 export default {
   authToken

--- a/tests/comment.test.js
+++ b/tests/comment.test.js
@@ -14,7 +14,7 @@ describe('Comment on Article', () => {
   it('should send back a token after sucessful login', (done) => {
     chai.request(app)
       .post('/api/users/login')
-      .send(user.userTrue)
+      .send(user.adminLogin)
       .end((err, res) => {
         res.should.have.status(200);
         authToken = res.body.user.token; // get the token


### PR DESCRIPTION
#### What does this PR do?

- Users should be able to share articles across different channels

#### Description of Task to be completed

- Add endpoint for sharing articles to `Facebook`, `Twitter` or `Mail`

- Check existing article's slug

- Add tests for the endpoint

- Document the endpoint

#### How should this be manually tested?

1. Run the following commands in the terminal.
```
git clone https://github.com/andela/ah-92explorers-backend.git
cd ah-92explorers-backend
git checkout ft-share-articles-166790011
npm install
npm start
```

2. Test endpoints, in Postman:

- Share on Twitter via `http://localhost:3000/api/articles/:slug/share/twitter`
- Share on Facebook via `http://localhost:3000/api/articles/:slug/share/facebook`
- Share on Mail via `http://localhost:3000/api/articles/:slug/share/mail`

#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?
[#166790011](https://www.pivotaltracker.com/story/show/166790011)
#### Screenshots (if appropriate)

- Shared on Twitter
<img width="758" alt="Screen Shot 2019-07-21 at 18 51 53" src="https://user-images.githubusercontent.com/40357462/61595581-2c4d9880-abf9-11e9-86d2-5eecfb8c1807.png">

- Shared on Facebook
<img width="698" alt="Screen Shot 2019-07-21 at 18 50 38" src="https://user-images.githubusercontent.com/40357462/61595588-340d3d00-abf9-11e9-8ccd-2e0608ec8a96.png">

- Shared on Mail
<img width="605" alt="Screen Shot 2019-07-21 at 18 58 46" src="https://user-images.githubusercontent.com/40357462/61595593-3ec7d200-abf9-11e9-9f2c-05f50382a5d0.png">

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I don't have more than 3 major commits on this PR