### PR TITLE
#168248733 Fix Bug On Rating Article Association

### DIFF
--- a/controllers/article.js
+++ b/controllers/article.js
@@ -174,6 +174,11 @@ class Article {
                 attributes: ['username', 'image']
               }
             ]
+          },
+          {
+            as: 'ratings',
+            model: ratings,
+            attributes: ['articleSlug', 'rating']
           }
         ]
       });
@@ -190,6 +195,7 @@ class Article {
           tagList,
           image,
           author,
+          rating: article.ratings
         };
         return res.status(200).json({ article: payload });
       }


### PR DESCRIPTION
#### What does this PR do?

- Ensure ratings are being retrieved on an article

#### Description of Task to be completed

- Add aliases to link ratings to articles

#### How should this be manually tested?

```
git clone git@github.com:andela/ah-92explorers-backend.git
cd ah-92explorers-backend
git checkout bg-fix-rating-article-association-168248733
```
2. run `npm run dev`

3. Using Postman (or similar) send a 
`GET`: `http://localhost:3000/api/articles/:slug`

#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?
[#168248733](https://www.pivotaltracker.com/story/show/168248733)
#### Screenshots (if appropriate)
<img width="624" alt="Screenshot 2019-09-02 16 35 37" src="https://user-images.githubusercontent.com/40357462/64122201-35f22080-cda1-11e9-8495-15504f4c86eb.png">

#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I don't have more than 3 major commits on this PR