### PR TITLE
#168405054 Fix bug Users should Be Able To Like Or Dislike An Article

### DIFF
--- a/controllers/likes.js
+++ b/controllers/likes.js
@@ -61,7 +61,7 @@ class Like {
               typeState: 1
             },
             {
-              where: { articleSlug: article.slug }
+              where: { articleSlug: article.slug, userId: user.id }
             }
           );
           return res.status(201).json({
@@ -122,7 +122,7 @@ class Like {
               typeState: 0
             },
             {
-              where: { articleSlug: article.slug }
+              where: { articleSlug: article.slug, userId: user.id }
             }
           );
           return res.status(201).json({


### PR DESCRIPTION
#### What does this PR do?
Enables a user to like/dislike an article
#### Description of Task to be completed
- To set up like and dislike functionality
#### How should this be manually tested?
1. Run the following commands in the terminal
```
git clone https://github.com/andela/ah-92explorers-backend.git
cd ah-92explorers-backend
git checkout ft-like-unlike-article-166790003
npm install
npm start
```
2. Create a .env file and add the following snippets
```
DATABASE_URL=postgres://username:password@localhost:5432/authorshaven
DATABASE_=postgres://username:password@localhost:5432/testing-ah
SECRET=whatever you want it to be
```
3. Install `sequelize` globally
```
sudo npm install -g sequelize
```
4.  Create a database using `sequelize db:create`
5. Install and setup Postman to consume CRUD endpoints
6. Run the following requests in Postman using `localhost:3000`
## Endpoints
|  Method  |  Endpoint  |  Task  |
|  --- |  --- |  ---  |
|  `POST`  |  `/api/like/:articleSlug`  |  `like an article`  |
|  `POST`  |  `/api/dislike/:articleSlug`  |  `dislike an article`  |
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#166790003](https://www.pivotaltracker.com/story/show/166790003)
#### Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I don't have more than 3 major commits on this PR