### PR TITLE
#168426852 Add Addition Flags In The Notification Subscription Response Body

### DIFF
--- a/controllers/likes.js
+++ b/controllers/likes.js
@@ -40,7 +40,9 @@ class Like {
           await notificationForFavorite(article.id, message, article.authorId, article.slug);
           await notifyFavoritees(article.id, message, article.authorId, article.slug);
           return res.status(201).json({
-            message: 'successfully liked article'
+            message: 'successfully liked article',
+            likes: article.likes,
+            username: user.username,
           });
 
         case like.typeState === 1:
@@ -52,8 +54,10 @@ class Like {
               }
             }
           );
-          return res.status(204).json({
-            message: 'successfully unliked article'
+          return res.status(200).json({
+            message: 'successfully unliked article',
+            likes: article.likes,
+            username: user.username,
           });
         case like.typeState === 0:
           await likes.update(
@@ -61,11 +65,13 @@ class Like {
               typeState: 1
             },
             {
-              where: { articleSlug: article.slug }
+              where: { articleSlug: article.slug, userId: user.id }
             }
           );
           return res.status(201).json({
-            message: 'successfully liked article'
+            message: 'successfully liked article',
+            likes: article.likes,
+            username: user.username,
           });
       }
     } catch (error) {
@@ -101,7 +107,9 @@ class Like {
             typeState: 0
           });
           return res.status(201).json({
-            message: 'successfully disliked article'
+            message: 'successfully disliked article',
+            likes: article.likes,
+            username: user.username,
           });
 
         case like.typeState === 0:
@@ -113,8 +121,10 @@ class Like {
               }
             }
           );
-          return res.status(204).json({
-            message: 'successfully unliked article'
+          return res.status(200).json({
+            message: 'successfully undisliked article',
+            likes: article.likes,
+            username: user.username,
           });
         case like.typeState === 1:
           await likes.update(
@@ -122,11 +132,13 @@ class Like {
               typeState: 0
             },
             {
-              where: { articleSlug: article.slug }
+              where: { articleSlug: article.slug, userId: user.id }
             }
           );
           return res.status(201).json({
-            message: 'successfully disliked article'
+            message: 'successfully disliked article',
+            likes: article.likes,
+            username: user.username,
           });
       }
     } catch (error) {

--- a/controllers/notifications.js
+++ b/controllers/notifications.js
@@ -173,6 +173,7 @@ export const subscribe = async (req, res) => {
   );
   res.status(200).json({
     user: updatedUser[1].notificationsOpt ? 'successfully subscribed to email notifications'
-      : 'successfully unsubscribed to email notifications'
+      : 'successfully unsubscribed to email notifications',
+    opted: allow,
   });
 };

--- a/models/users.js
+++ b/models/users.js
@@ -62,7 +62,7 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: true
     },
-    notificationsOpt: { type: DataTypes.BOOLEAN },
+    notificationsOpt: { type: DataTypes.BOOLEAN, defaultValue: false },
     accessLevel: {
       type: DataTypes.INTEGER,
       defaultValue: '0'

--- a/tests/likes.test.js
+++ b/tests/likes.test.js
@@ -45,7 +45,7 @@ describe('Testing if user can like and dislike', () => {
       .set('Authorization', `Bearer ${data[0]}`)
       .end((err, res) => {
         const { status } = res;
-        expect(status).to.equal(204);
+        expect(status).to.equal(200);
         done();
       });
   });
@@ -69,7 +69,7 @@ describe('Testing if user can like and dislike', () => {
       .set('Authorization', `Bearer ${data[0]}`)
       .end((err, res) => {
         const { status } = res;
-        expect(status).to.equal(204);
+        expect(status).to.equal(200);
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
adds addition boolean flag to the response body
#### Description of Task to be completed
- enable accurate check for a subscription in frontend
#### How should this be manually tested?
1. Run the following commands in the terminal
```
git clone https://github.com/andela/ah-92explorers-backend.git
cd ah-92explorers-backend
git checkout bg-add-addition-flags-168426852
npm install
npm start
```
2. Create a .env file and add the following snippets
```
DATABASE_URL=postgres://username:password@localhost:5432/authorshaven
DATABASE_=postgres://username:password@localhost:5432/testing-ah
SECRET=whatever you want it to be
```
3. Install `sequelize` globally
```
sudo npm install -g sequelize
```
4.  Create a database using `sequelize db:create`
5. Install and setup Postman to consume CRUD endpoints
6. Run the following requests in Postman using `localhost:3000`
## Endpoints
|  Method  |  Endpoint  |  Task  |
|  --- |  --- |  ---  |
|  `PATCH`  |  `/api/notifications/subscribe`  |  `add additional flags`  |
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#168426852](https://www.pivotaltracker.com/story/show/168426852)
#### Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I don't have more than 3 major commits on this PR